### PR TITLE
Fixes #4 - Unable to display a single tweet

### DIFF
--- a/components/EmbedTimeline.php
+++ b/components/EmbedTimeline.php
@@ -130,6 +130,7 @@ class EmbedTimeline extends ComponentBase
         array_walk($attributes, function(&$value, $key) {
             switch ($value) {
                 case '1':
+                    if($key != 'tweet-limit')
                     $value = 'true';
                     break;
 


### PR DESCRIPTION
Fixes setting Tweet Limit to 1 allowing for a single tweet to be displayed.
