### PR TITLE
Fixed embedded timeline (issue #13)

### DIFF
--- a/components/EmbedTimeline.php
+++ b/components/EmbedTimeline.php
@@ -6,7 +6,8 @@ use Cms\Classes\ComponentBase;
 class EmbedTimeline extends ComponentBase
 {
     public $timelineAttributes;
-
+	public $timelineURI;
+	
     public function componentDetails()
     {
         return [
@@ -18,12 +19,10 @@ class EmbedTimeline extends ComponentBase
     public function defineProperties()
     {
         return [
-            'widget-id' => [
-                 'title'             => 'Widget ID',
-                 'description'       => 'To create a timeline you must be signed in to twitter.com and visit the widgets section [https://twitter.com/settings/widgets] of your settings page.',
+            'timeline' => [
+                 'title'             => 'Timeline',
+                 'description'       => 'The timeline to show starting with the username. For example "TwitterDev" for the TwitterDev timeline. "TwitterDev/likes" for likes. "TwitterDev/lists/national-parks" for the national-parks list.',
                  'type'              => 'string',
-                 'validationPattern' => '^\d+$',
-                 'validationMessage' => 'The widget ID can only contain digits and is required.'
             ],
             'tweet-limit' => [
                  'title'             => 'Tweet limit',
@@ -118,12 +117,25 @@ class EmbedTimeline extends ComponentBase
     public function onRun()
     {
         $this->timelineAttributes = $this->page['timelineAttributes'] = $this->loadTimelineAttributes();
+        $this->timelineURI = $this->page['timelineURI'] = $this->property('timeline');
     }
 
     protected function loadTimelineAttributes()
     {
         $attributes = $this->getProperties();
 
+		// the widget-id is no longer used, so we
+		// do not want to include it if we have specified a timeline
+		if(array_key_exists('timeline', $attributes) && array_key_exists('widget-id', $attributes)) {
+			unset($attributes['widget-id']);
+		}
+		
+		// the timeline is not an attribute we want to add, 
+		// so we do not include it in the attributes
+		if(array_key_exists('timeline', $attributes)) {
+			unset($attributes['timeline']);
+		}
+		
         /*
          * Convert booleans
          */

--- a/components/embedtimeline/default.htm
+++ b/components/embedtimeline/default.htm
@@ -1,6 +1,6 @@
 <a
     class="twitter-timeline"
-    href="https://twitter.com/twitterapi" {{ __SELF__.timelineAttributes|raw }}>
+    href="https://twitter.com/{{__SELF__.timelineURI}}" {{ __SELF__.timelineAttributes|raw }}>
     Tweets Timeline
 </a>
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -3,3 +3,4 @@
 1.0.3: Minor improvements to the code.
 1.0.4: Adds a new latest tweet component.
 1.0.5: Fixes bug when setting component parameters.
+1.0.6: Fixes the embeded timeline component for updated Twitter API.


### PR DESCRIPTION
Fix for Issue #13 

Removed the widget-id property and added a new timeline property with
some examples.

The onRun now stores the timeline property into a timelineURI
parameter, and the load attributes now ignores widget-id if a timeline
property is defined. It also correctly handles not adding a
data-timeline to the anchor tag.